### PR TITLE
Add Release Pipeline workflow to GitHub Actions

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Bootstrap dependencies
         run: npm run bootstrap
       - name: Git commit version bump
-        run: git commit -am 'chore: Release {{ github.events.inputs.version }}'
+        run: git commit -am "chore:Release ${{ github.events.inputs.version }}"
       - name: Git push
         run: git push
       - name: Publish to npm


### PR DESCRIPTION
**What problem is this solving?**

With this pull request, we introduce a CD pipeline which automates the publishing and tagging of releases.

This workflow will be held in the folder ./github/release-build.yml

- CD jobs will only be ran when a release is to be made
- A version to tag the release with will be required and follows a sematic version of x.x.x format