### PR TITLE
Make Master Build to run on three OS

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -10,7 +10,9 @@ jobs:
     strategy:
       matrix:
         os:
+          - macos-latest
           - ubuntu-latest
+          - windows-latest
         node-version: [14.x]
 
     steps:


### PR DESCRIPTION
This is to enhance the master build to run on three OS on push to master branch to cover the scenario where something is pushed without a PR as mentioned in the [master build PR](https://github.com/aws-observability/aws-otel-js/pull/6)