### PR TITLE
Publish packages individually in Release Pipeline

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -29,13 +29,13 @@ jobs:
       - name: Git push
         run: git push
       - name: Publish to npm
-        run: npm publish
-        env:
+        run: |
           for dir in $(ls packages); do
             pushd packages/$dir
             npm publish
             popd
           done
+        env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Create Release
         id: create_release


### PR DESCRIPTION
**What problem is this solving?**

Currently, the CD Release pipeline automates the publishing and tagging of releases. However, it publishes the entire repository as an entire package which causes errors with installing the package through npm. In order, to resolve that we add a couple additional bash commands to publish each package within ./packages seperately as done in the upstream repo.
