### PR TITLE
Update Master Build to push to Correct ECR repository

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -37,8 +37,6 @@ jobs:
     steps:
       - name : Checkout Repository
         uses: actions/checkout@v2
-      - name : Set up QEMU
-        uses : docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Cache Docker layer
@@ -57,6 +55,6 @@ jobs:
         with:
           path: integ-test/js-sdk-emitter/Dockerfile
           context: .
-          tags: 611364707713.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-otel-js-sample-app:$ {{ github.sha }}
-          push: ${{ secrets.AWS_REGISTRY_ACCOUNT_ID }}.${{ secrets.INTEG_TEST_AWS_KEY_ID }}.dkr.ecr.us-west-2.amazonaws.com/aws-otel-js-sample-app
+          tags: 611364707713.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-otel-js-sample-app:${{ github.sha }}
+          push: true
 


### PR DESCRIPTION
**What problem does this Pull Request solve?**

This pull request builds a docker image in /integ-test/js-sdk-emitter/Dockerfile and pushes the image to ECR. This allows the newly built image to be tested on commit to master branch by the otel-test-framework. The master build will only build the docker image and push to ECR after the previous test build passes. 