### PR TITLE
move dev stuff to dev dependencies

### DIFF
--- a/packages/opentelemetry-id-generator-aws-xray/package.json
+++ b/packages/opentelemetry-id-generator-aws-xray/package.json
@@ -35,8 +35,7 @@
     "LICENSE",
     "README.md"
   ],
-  "dependencies": {
-    "@opentelemetry/core": "^0.10.2",
+  "devDependencies": {
     "@types/mocha": "7.0.2",
     "@types/node": "12.12.47",
     "@types/sinon": "9.0.4",
@@ -62,5 +61,8 @@
     "tslint-microsoft-contrib": "6.2.0",
     "typescript": "3.9.6",
     "webpack": "4.43.0"
+  },
+  "dependencies": {
+    "@opentelemetry/core": "^0.10.2"
   }
 }


### PR DESCRIPTION
This seems to fix the issue I was complaining about in #25 although I'm not 100% sure I haven't moved something to devDependencies that shouldn't be there.

Fun fact: in the process of link-installing this into my project, the following change was added to the tree:

```
diff --git a/packages/opentelemetry-id-generator-aws-xray/src/version.ts b/packages/opentelemetry-id-generator-aws-xray/src/version.ts
index 65de257..11f0de8 100644
--- a/packages/opentelemetry-id-generator-aws-xray/src/version.ts
+++ b/packages/opentelemetry-id-generator-aws-xray/src/version.ts
@@ -1,18 +1,18 @@
 /*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS'" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- *
- */
+* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License'").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* or in the "license'" file accompanying this file. This file is distributed
+* on an "AS IS'" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*
+*/
 
 // this is autogenerated file, see scripts/version-update.js
 export const VERSION = '0.12.0';
```

which maybe seems like it shouldn't have happened, but what do I know?