### PR TITLE
Add metrics sample app for JavaScript SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ package.json.lerna_backup
 
 # VsCode configs
 .vscode/
+.idea/
+

--- a/integ-test/js-sdk-emitter/metrics.js
+++ b/integ-test/js-sdk-emitter/metrics.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const { ConsoleLogger, LogLevel } = require('@opentelemetry/core');
+const { CollectorMetricExporter } = require('@opentelemetry/exporter-collector-grpc');
+const { MeterProvider } = require('@opentelemetry/metrics');
+
+/** The OTLP Metrics gRPC Collector */
+const metricExporter = new CollectorMetricExporter({
+  serviceName: 'aws-otel-js-sample',
+  logger: new ConsoleLogger(LogLevel.DEBUG),
+});
+
+/** The OTLP Metrics Provider with OTLP gRPC Metric Exporter and Metrics collection Interval  */
+const meter = new MeterProvider({
+  exporter: metricExporter,
+  interval: 1000,
+}).getMeter('aws-otel-js');
+
+/** Counter Metrics */
+const playloadMetric = meter.createCounter('playload', {
+  description: 'Metric for counting request playload size',
+});
+
+/** Up and Down Counter Metrics */
+const activeReqMetric = meter.createUpDownCounter('activeRequest', {
+  description: 'Metric for record active requests',
+});
+
+/** Value Recorder Metrics with Histogram */
+const requestLatency = meter.createValueRecorder('latency', {
+  description: 'Metric for record request latency',
+});
+
+/** Define Metrics Dimensions */
+const labels = { pid: process.pid, env: 'beta' };
+
+/** Send the defined metrics every seconds */
+setInterval(() => {
+  playloadMetric.bind(labels).add(1);
+  activeReqMetric.bind(labels).add(Math.random() > 0.5 ? 1 : -1);
+  requestLatency.bind(labels).record(Math.random() * 1000)
+}, 1000);

--- a/integ-test/js-sdk-emitter/metrics.js
+++ b/integ-test/js-sdk-emitter/metrics.js
@@ -17,8 +17,8 @@ const meter = new MeterProvider({
 }).getMeter('aws-otel-js');
 
 /** Counter Metrics */
-const playloadMetric = meter.createCounter('playload', {
-  description: 'Metric for counting request playload size',
+const payloadMetric = meter.createCounter('payload', {
+  description: 'Metric for counting request payload size',
 });
 
 /** Up and Down Counter Metrics */
@@ -36,7 +36,7 @@ const labels = { pid: process.pid, env: 'beta' };
 
 /** Send the defined metrics every seconds */
 setInterval(() => {
-  playloadMetric.bind(labels).add(1);
+  payloadMetric.bind(labels).add(1);
   activeReqMetric.bind(labels).add(Math.random() > 0.5 ? 1 : -1);
   requestLatency.bind(labels).record(Math.random() * 1000)
 }, 1000);

--- a/integ-test/js-sdk-emitter/metrics.js
+++ b/integ-test/js-sdk-emitter/metrics.js
@@ -8,6 +8,7 @@ const { MeterProvider } = require('@opentelemetry/metrics');
 const metricExporter = new CollectorMetricExporter({
   serviceName: 'aws-otel-js-sample',
   logger: new ConsoleLogger(LogLevel.DEBUG),
+  url: (process.env.OTEL_EXPORTER_OTLP_ENDPOINT) ? process.env.OTEL_EXPORTER_OTLP_ENDPOINT : "localhost:55680"
 });
 
 /** The OTLP Metrics Provider with OTLP gRPC Metric Exporter and Metrics collection Interval  */

--- a/integ-test/js-sdk-emitter/package.json
+++ b/integ-test/js-sdk-emitter/package.json
@@ -3,7 +3,10 @@
   "version": "0.11.0",
   "description": "test-application for javascript SDK",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "start:traces": "node server.js",
+    "start:metrics": "node metrics.js"
+  },
   "keywords": [
     "opentelemetry",
     "http",
@@ -34,4 +37,3 @@
     "cross-env": "^6.0.0"
   }
 }
-


### PR DESCRIPTION
Add Metrics sample app which will send metrics to OTel Collector via OTLP gRPC exporter.