### PR TITLE
Update upstream dependencies

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,9 +3,6 @@ module.exports = {
     "@typescript-eslint",
     "header"
   ],
-  extends: [
-      "./node_modules/gts",
-  ],
   parser: "@typescript-eslint/parser",
   parserOptions: {
       "project": "./tsconfig.json"

--- a/packages/opentelemetry-id-generator-aws-xray/package.json
+++ b/packages/opentelemetry-id-generator-aws-xray/package.json
@@ -63,6 +63,6 @@
     "webpack": "4.43.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "^0.13.0"
+    "@opentelemetry/core": "^0.15.0"
   }
 }

--- a/packages/opentelemetry-id-generator-aws-xray/package.json
+++ b/packages/opentelemetry-id-generator-aws-xray/package.json
@@ -63,6 +63,6 @@
     "webpack": "4.43.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "^0.15.0"
+    "@opentelemetry/core": "^0.16.0"
   }
 }

--- a/packages/opentelemetry-id-generator-aws-xray/src/platform/browser/AwsXrayIdGenerator.ts
+++ b/packages/opentelemetry-id-generator-aws-xray/src/platform/browser/AwsXrayIdGenerator.ts
@@ -18,7 +18,7 @@ import { IdGenerator } from '@opentelemetry/core';
 
 const SPAN_ID_BYTES = 8;
 const TRACE_ID_BYTES = 16;
-const TIME_BYTES = 4;
+const EPOCH_BYTES = 4;
 
 /** IdGenerator that generates trace IDs conforming to AWS X-Ray format.
  * https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html#xray-api-traceids
@@ -29,32 +29,38 @@ export class AwsXRayIdGenerator implements IdGenerator {
    * characters corresponding to 128 bits. The first 4 bytes correspond to the current
    * time, in seconds, as per X-Ray trace ID format.
    */
-  generateTraceId = getIdGenerator(true, TRACE_ID_BYTES - TIME_BYTES);
+  generateTraceId = generateTraceIdImpl;
 
   /**
    * Returns a random 8-byte span ID formatted/encoded as a 16 lowercase hex
    * characters corresponding to 64 bits.
    */
-  generateSpanId = getIdGenerator(false, SPAN_ID_BYTES);
+  generateSpanId = generateSpanIdImpl;
 }
 
 const SHARED_CHAR_CODES_ARRAY = Array(32);
-function getIdGenerator(timeUsage: boolean, bytes: number): () => string {
-  return function generateId() {
-    for (let i = 0; i < bytes * 2; i++) {
-      SHARED_CHAR_CODES_ARRAY[i] = Math.floor(Math.random() * 16) + 48;
-      // valid hex characters in the range 48-57 and 97-102
-      if (SHARED_CHAR_CODES_ARRAY[i] >= 58) {
-        SHARED_CHAR_CODES_ARRAY[i] += 39;
-      }
+
+function generateTraceIdImpl(): string {
+  const epoch = Math.floor(Date.now() / 1000).toString(16);
+  const rand = generateRandomBytes(TRACE_ID_BYTES - EPOCH_BYTES);
+  return epoch + rand;
+}
+
+function generateSpanIdImpl(): string {
+  return generateRandomBytes(SPAN_ID_BYTES);
+}
+
+function generateRandomBytes(bytes: number) {
+  for (let i = 0; i < bytes * 2; i++) {
+    SHARED_CHAR_CODES_ARRAY[i] = Math.floor(Math.random() * 16) + 48;
+    // valid hex characters in the range 48-57 and 97-102
+    if (SHARED_CHAR_CODES_ARRAY[i] >= 58) {
+      SHARED_CHAR_CODES_ARRAY[i] += 39;
     }
-    const nowSec = timeUsage ? Math.floor(Date.now() / 1000).toString(16) : '';
-    return (
-      nowSec +
-      String.fromCharCode.apply(
-        null,
-        SHARED_CHAR_CODES_ARRAY.slice(0, bytes * 2)
-      )
-    );
-  };
+  }
+
+  return String.fromCharCode.apply(
+    null,
+    SHARED_CHAR_CODES_ARRAY.slice(0, bytes * 2)
+  );
 }

--- a/packages/opentelemetry-id-generator-aws-xray/src/platform/browser/AwsXrayIdGenerator.ts
+++ b/packages/opentelemetry-id-generator-aws-xray/src/platform/browser/AwsXrayIdGenerator.ts
@@ -29,26 +29,22 @@ export class AwsXRayIdGenerator implements IdGenerator {
    * characters corresponding to 128 bits. The first 4 bytes correspond to the current
    * time, in seconds, as per X-Ray trace ID format.
    */
-  generateTraceId = generateTraceIdImpl;
+  generateTraceId = (): string => {
+    const epoch = Math.floor(Date.now() / 1000).toString(16);
+    const rand = generateRandomBytes(TRACE_ID_BYTES - EPOCH_BYTES);
+    return epoch + rand;
+  };
 
   /**
    * Returns a random 8-byte span ID formatted/encoded as a 16 lowercase hex
    * characters corresponding to 64 bits.
    */
-  generateSpanId = generateSpanIdImpl;
+  generateSpanId = (): string => {
+    return generateRandomBytes(SPAN_ID_BYTES);
+  };
 }
 
 const SHARED_CHAR_CODES_ARRAY = Array(32);
-
-function generateTraceIdImpl(): string {
-  const epoch = Math.floor(Date.now() / 1000).toString(16);
-  const rand = generateRandomBytes(TRACE_ID_BYTES - EPOCH_BYTES);
-  return epoch + rand;
-}
-
-function generateSpanIdImpl(): string {
-  return generateRandomBytes(SPAN_ID_BYTES);
-}
 
 function generateRandomBytes(bytes: number) {
   for (let i = 0; i < bytes * 2; i++) {

--- a/packages/opentelemetry-id-generator-aws-xray/src/platform/node/AwsXrayIdGenerator.ts
+++ b/packages/opentelemetry-id-generator-aws-xray/src/platform/node/AwsXrayIdGenerator.ts
@@ -30,26 +30,22 @@ export class AwsXRayIdGenerator implements IdGenerator {
    * characters corresponding to 128 bits. The first 4 bytes correspond to the current
    * time, in seconds, as per X-Ray trace ID format.
    */
-  generateTraceId = generateTraceIdImpl;
+  generateTraceId = (): string => {
+    const epoch = Math.floor(Date.now() / 1000).toString(16);
+    const rand = generateRandomBytes(TRACE_ID_BYTES - EPOCH_BYTES);
+    return epoch + rand;
+  };
 
   /**
    * Returns a random 8-byte span ID formatted/encoded as a 16 lowercase hex
    * characters corresponding to 64 bits.
    */
-  generateSpanId = generateSpanIdImpl;
+  generateSpanId = (): string => {
+    return generateRandomBytes(SPAN_ID_BYTES);
+  };
 }
 
 const SHARED_BUFFER = Buffer.allocUnsafe(TRACE_ID_BYTES);
-
-function generateTraceIdImpl(): string {
-  const epoch = Math.floor(Date.now() / 1000).toString(16);
-  const rand = generateRandomBytes(TRACE_ID_BYTES - EPOCH_BYTES);
-  return epoch + rand;
-}
-
-function generateSpanIdImpl(): string {
-  return generateRandomBytes(SPAN_ID_BYTES);
-}
 
 function generateRandomBytes(bytes: number): string {
   for (let i = 0; i < bytes / 4; i++) {

--- a/packages/opentelemetry-propagator-aws-xray/package.json
+++ b/packages/opentelemetry-propagator-aws-xray/package.json
@@ -71,8 +71,8 @@
     "webpack": "4.43.0"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.15.0",
-    "@opentelemetry/context-base": "^0.15.0",
-    "@opentelemetry/core": "^0.15.0"
+    "@opentelemetry/api": "^0.16.0",
+    "@opentelemetry/context-base": "^0.16.0",
+    "@opentelemetry/core": "^0.16.0"
   }
 }

--- a/packages/opentelemetry-propagator-aws-xray/package.json
+++ b/packages/opentelemetry-propagator-aws-xray/package.json
@@ -71,8 +71,8 @@
     "webpack": "4.43.0"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.13.0",
-    "@opentelemetry/context-base": "^0.13.0",
-    "@opentelemetry/core": "^0.13.0"
+    "@opentelemetry/api": "^0.15.0",
+    "@opentelemetry/context-base": "^0.15.0",
+    "@opentelemetry/core": "^0.15.0"
   }
 }

--- a/packages/opentelemetry-propagator-aws-xray/src/AWSXRayPropagator.ts
+++ b/packages/opentelemetry-propagator-aws-xray/src/AWSXRayPropagator.ts
@@ -67,12 +67,11 @@ export class AWSXRayPropagator implements TextMapPropagator {
     const timestamp = otTraceId.substring(0, TRACE_ID_FIRST_PART_LENGTH);
     const randomNumber = otTraceId.substring(TRACE_ID_FIRST_PART_LENGTH);
 
-    const xrayTraceId = `1-${timestamp}-${randomNumber}`;
     const parentId = spanContext.spanId;
     const samplingFlag = spanContext.traceFlags ? IS_SAMPLED : NOT_SAMPLED;
     // TODO: Add OT trace state to the X-Ray trace header
 
-    const traceHeader = `Root=${xrayTraceId};Parent=${parentId};Sampled=${samplingFlag}`;
+    const traceHeader = `Root=1-${timestamp}-${randomNumber};Parent=${parentId};Sampled=${samplingFlag}`;
     setter.set(carrier, AWSXRAY_TRACE_ID_HEADER, traceHeader);
   }
 

--- a/packages/opentelemetry-propagator-aws-xray/src/AWSXRayPropagator.ts
+++ b/packages/opentelemetry-propagator-aws-xray/src/AWSXRayPropagator.ts
@@ -26,8 +26,8 @@ import {
   isValidTraceId,
   INVALID_TRACEID,
   INVALID_SPANID,
-  getParentSpanContext,
-  setExtractedSpanContext,
+  getSpanContext,
+  setSpanContext,
   INVALID_SPAN_CONTEXT,
 } from '@opentelemetry/api';
 
@@ -60,7 +60,7 @@ const NOT_SAMPLED = '0';
  */
 export class AWSXRayPropagator implements TextMapPropagator {
   inject(context: Context, carrier: unknown, setter: TextMapSetter) {
-    const spanContext = getParentSpanContext(context);
+    const spanContext = getSpanContext(context);
     if (!spanContext || !isSpanContextValid(spanContext)) return;
 
     const otTraceId = spanContext.traceId;
@@ -80,7 +80,7 @@ export class AWSXRayPropagator implements TextMapPropagator {
     const spanContext = this.getSpanContextFromHeader(carrier, getter);
     if (!isSpanContextValid(spanContext)) return context;
 
-    return setExtractedSpanContext(context, spanContext);
+    return setSpanContext(context, spanContext);
   }
 
   fields(): string[] {

--- a/packages/opentelemetry-propagator-aws-xray/test/AWSXRayPropagator.test.ts
+++ b/packages/opentelemetry-propagator-aws-xray/test/AWSXRayPropagator.test.ts
@@ -19,8 +19,8 @@ import {
   defaultTextMapSetter,
   SpanContext,
   TraceFlags,
-  getActiveSpan,
-  setExtractedSpanContext,
+  getSpan,
+  setSpanContext,
   INVALID_SPAN_CONTEXT,
 } from '@opentelemetry/api';
 import { TraceState } from '@opentelemetry/core';
@@ -29,6 +29,8 @@ import {
   AWSXRayPropagator,
   AWSXRAY_TRACE_ID_HEADER,
 } from '../src/AWSXRayPropagator';
+
+import { describe } from 'mocha';
 
 describe('AWSXRayPropagator', () => {
   const xrayPropagator = new AWSXRayPropagator();
@@ -51,7 +53,7 @@ describe('AWSXRayPropagator', () => {
         traceFlags: SAMPLED_TRACE_FLAG,
       };
       xrayPropagator.inject(
-        setExtractedSpanContext(ROOT_CONTEXT, spanContext),
+        setSpanContext(ROOT_CONTEXT, spanContext),
         carrier,
         defaultTextMapSetter
       );
@@ -69,7 +71,7 @@ describe('AWSXRayPropagator', () => {
         traceFlags: NOT_SAMPLED_TRACE_FLAG,
       };
       xrayPropagator.inject(
-        setExtractedSpanContext(ROOT_CONTEXT, spanContext),
+        setSpanContext(ROOT_CONTEXT, spanContext),
         carrier,
         defaultTextMapSetter
       );
@@ -90,7 +92,7 @@ describe('AWSXRayPropagator', () => {
         traceState: traceState,
       };
       xrayPropagator.inject(
-        setExtractedSpanContext(ROOT_CONTEXT, spanContext),
+        setSpanContext(ROOT_CONTEXT, spanContext),
         carrier,
         defaultTextMapSetter
       );
@@ -111,7 +113,7 @@ describe('AWSXRayPropagator', () => {
     it('inject default invalid spanContext - should inject nothing', () => {
       const spanContext: SpanContext = INVALID_SPAN_CONTEXT;
       xrayPropagator.inject(
-        setExtractedSpanContext(ROOT_CONTEXT, spanContext),
+        setSpanContext(ROOT_CONTEXT, spanContext),
         carrier,
         defaultTextMapSetter
       );
@@ -132,7 +134,7 @@ describe('AWSXRayPropagator', () => {
     it('should extract sampled context', () => {
       carrier[AWSXRAY_TRACE_ID_HEADER] =
         'Root=1-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=53995c3f42cd8ad8;Sampled=1';
-      const extractedSpanContext = getActiveSpan(
+      const extractedSpanContext = getSpan(
         xrayPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
       )?.context();
 
@@ -147,7 +149,7 @@ describe('AWSXRayPropagator', () => {
     it('should extract sampled context with arbitrary order', () => {
       carrier[AWSXRAY_TRACE_ID_HEADER] =
         'Parent=53995c3f42cd8ad8;Sampled=1;Root=1-8a3c60f7-d188f8fa79d48a391a778fa6';
-      const extractedSpanContext = getActiveSpan(
+      const extractedSpanContext = getSpan(
         xrayPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
       )?.context();
 
@@ -162,7 +164,7 @@ describe('AWSXRayPropagator', () => {
     it('should extract context with additional fields', () => {
       carrier[AWSXRAY_TRACE_ID_HEADER] =
         'Root=1-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=53995c3f42cd8ad8;Sampled=1;Foo=Bar';
-      const extractedSpanContext = getActiveSpan(
+      const extractedSpanContext = getSpan(
         xrayPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
       )?.context();
 
@@ -177,7 +179,7 @@ describe('AWSXRayPropagator', () => {
 
     it('extract empty header value - should return undefined', () => {
       carrier[AWSXRAY_TRACE_ID_HEADER] = '';
-      const extractedSpanContext = getActiveSpan(
+      const extractedSpanContext = getSpan(
         xrayPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
       )?.context();
 
@@ -187,7 +189,7 @@ describe('AWSXRayPropagator', () => {
     it('extract invalid traceId - should return undefined', () => {
       carrier[AWSXRAY_TRACE_ID_HEADER] =
         'Root=1-abcdefgh-ijklmnopabcdefghijklmnop;Parent=53995c3f42cd8ad8;Sampled=0';
-      const extractedSpanContext = getActiveSpan(
+      const extractedSpanContext = getSpan(
         xrayPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
       )?.context();
 
@@ -197,7 +199,7 @@ describe('AWSXRayPropagator', () => {
     it('extract invalid traceId size - should return undefined', () => {
       carrier[AWSXRAY_TRACE_ID_HEADER] =
         'Root=1-8a3c60f7-d188f8fa79d48a391a778fa600;Parent=53995c3f42cd8ad8;Sampled=0';
-      const extractedSpanContext = getActiveSpan(
+      const extractedSpanContext = getSpan(
         xrayPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
       )?.context();
 
@@ -207,7 +209,7 @@ describe('AWSXRayPropagator', () => {
     it('extract invalid traceId delimiter - should return undefined', () => {
       carrier[AWSXRAY_TRACE_ID_HEADER] =
         'Root=1*8a3c60f7+d188f8fa79d48a391a778fa6;Parent=53995c3f42cd8ad8;Sampled=1;Foo=Bar';
-      const extractedSpanContext = getActiveSpan(
+      const extractedSpanContext = getSpan(
         xrayPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
       )?.context();
 
@@ -217,7 +219,7 @@ describe('AWSXRayPropagator', () => {
     it('extract invalid spanId - should return undefined', () => {
       carrier[AWSXRAY_TRACE_ID_HEADER] =
         'Root=1-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=abcdefghijklmnop;Sampled=0';
-      const extractedSpanContext = getActiveSpan(
+      const extractedSpanContext = getSpan(
         xrayPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
       )?.context();
 
@@ -227,7 +229,7 @@ describe('AWSXRayPropagator', () => {
     it('extract invalid spanId size - should return undefined', () => {
       carrier[AWSXRAY_TRACE_ID_HEADER] =
         'Root=1-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=53995c3f42cd8ad800;Sampled=0';
-      const extractedSpanContext = getActiveSpan(
+      const extractedSpanContext = getSpan(
         xrayPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
       )?.context();
 
@@ -237,7 +239,7 @@ describe('AWSXRayPropagator', () => {
     it('extract invalid traceFlags - should return undefined', () => {
       carrier[AWSXRAY_TRACE_ID_HEADER] =
         'Root=1-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=53995c3f42cd8ad8;Sampled=';
-      const extractedSpanContext = getActiveSpan(
+      const extractedSpanContext = getSpan(
         xrayPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
       )?.context();
 
@@ -247,7 +249,7 @@ describe('AWSXRayPropagator', () => {
     it('extract invalid traceFlags length - should return undefined', () => {
       carrier[AWSXRAY_TRACE_ID_HEADER] =
         'Root=1-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=53995c3f42cd8ad8;Sampled=10220';
-      const extractedSpanContext = getActiveSpan(
+      const extractedSpanContext = getSpan(
         xrayPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
       )?.context();
 
@@ -257,7 +259,7 @@ describe('AWSXRayPropagator', () => {
     it('extract nonnumeric invalid traceFlags - should return undefined', () => {
       carrier[AWSXRAY_TRACE_ID_HEADER] =
         'Root=1-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=53995c3f42cd8ad8;Sampled=a';
-      const extractedSpanContext = getActiveSpan(
+      const extractedSpanContext = getSpan(
         xrayPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
       )?.context();
 
@@ -267,7 +269,7 @@ describe('AWSXRayPropagator', () => {
     it('extract invalid aws xray version - should return undefined', () => {
       carrier[AWSXRAY_TRACE_ID_HEADER] =
         'Root=2-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=53995c3f42cd8ad8;Sampled=1';
-      const extractedSpanContext = getActiveSpan(
+      const extractedSpanContext = getSpan(
         xrayPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
       )?.context();
 

--- a/packages/opentelemetry-propagator-aws-xray/tsconfig.json
+++ b/packages/opentelemetry-propagator-aws-xray/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "build"

--- a/sample-apps/README.md
+++ b/sample-apps/README.md
@@ -1,0 +1,32 @@
+# ADOT JavaScript Sample App
+
+A simple HTTP server that demonstrates OpenTelemetry instrumentation for JavaScript apps
+
+## Prerequisites
+
+* [NPM and Node.js](https://nodejs.org/en/download/) installed.
+* [ADOT Collector](https://aws-otel.github.io/docs/getting-started/collector) running in your environment
+
+## Getting Started
+
+Run the following commands to start the sample app:
+
+```bash
+git clone https://github.com/aws-observability/aws-otel-js.git
+cd aws-otel-js
+npx lerna bootstrap
+cd sample-apps
+npm install
+npm rb
+export LISTEN_ADDRESS=localhost:8080
+node server.js
+```
+
+## Using the sample app
+
+The sample app exposes the following routes. Visit them in your browser, then go to the AWS X-Ray console to see the traces they generate.
+
+* localhost:8080/ - healthcheck endpoint, generates a single span
+* localhost:8080/aws-sdk-call - Makes a traced request with the AWS SDK
+* localhost:8080/outgoing-http-call - Makes a traced downstream HTTP request
+

--- a/sample-apps/package.json
+++ b/sample-apps/package.json
@@ -22,16 +22,16 @@
     "@opentelemetry/core": "^0.13.0",
     "@opentelemetry/exporter-collector-grpc": "^0.13.0",
     "@opentelemetry/node": "^0.13.0",
-    "@opentelemetry/plugin-https": "^0.13.0",
     "@opentelemetry/plugin-http": "^0.13.0",
+    "@opentelemetry/plugin-https": "^0.13.0",
     "@opentelemetry/tracing": "^0.13.0",
+    "aws-sdk": "^2.799.0",
     "AWSXRayIdGenerator": "file:../packages/opentelemetry-id-generator-aws-xray",
     "AWSXRayPropagator": "file:../packages/opentelemetry-propagator-aws-xray",
-    "aws-sdk": "^2.799.0",
     "opentelemetry-plugin-aws-sdk": "0.0.13"
   },
   "devDependencies": {
-    "cross-env": "^6.0.0",
-    "@lerna/link": "^3.21.0"
+    "@lerna/link": "^3.21.0",
+    "cross-env": "^6.0.0"
   }
 }

--- a/sample-apps/tracer.js
+++ b/sample-apps/tracer.js
@@ -16,6 +16,7 @@
 
 'use strict'
 
+const { LogLevel } = require("@opentelemetry/core");
 const { SimpleSpanProcessor, ConsoleSpanExporter } = require("@opentelemetry/tracing");
 const { NodeTracerProvider } = require('@opentelemetry/node');
 const { CollectorTraceExporter } = require('@opentelemetry/exporter-collector-grpc');
@@ -31,6 +32,7 @@ module.exports = (serviceName) => {
 
   // create a provider for activating and tracking with AWS IdGenerator
   const tracerConfig = {
+    logLevel: LogLevel.ERROR,
     idGenerator: new AwsXRayIdGenerator(),
     plugins: {
       https: {


### PR DESCRIPTION
* Updated the upstream dependency for IDs generator and propagator to latest, and fixed breaking changes
* Cleaned up component code to be more readable and use interpolation instead of concatenation, which is [faster](https://stackoverflow.com/questions/29055518/are-es6-template-literals-faster-than-string-concatenation/29083467#29083467) in modern JS runtimes
* Added a minimal README to sample app, it's not much but we can expand on it (and the app) in the future
* Did NOT update the sample app to latest upstream version, because the 3rd party AWS SDK instrumentation is not yet compatible with newer upstream versions