### PR TITLE
Migrate integration tests to current pattern using docker-compose / p…

### DIFF
--- a/.github/collector/collector-config.yml
+++ b/.github/collector/collector-config.yml
@@ -2,37 +2,27 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
 
 exporters:
   logging:
     loglevel: info
   awsxray:
     region: us-west-2
-    local_mode: true
-    no_verify_ssl: true
   awsemf:
     region: us-west-2
-
-processors:
-  memory_limiter:
-    limit_mib: 100
-    check_interval: 5s
-  batch:
-  queued_retry:
 
 service:
   pipelines:
     traces:
-      processors:
-        - memory_limiter
       receivers:
         - otlp
       exporters:
-        # - logging
+        - logging
         - awsxray
     metrics:
       receivers:
         - otlp
       exporters:
-        # - logging
+        - logging
         - awsemf

--- a/.github/collector/docker-compose.yml
+++ b/.github/collector/docker-compose.yml
@@ -1,12 +1,41 @@
-version: "3.2"
+version: "3.7"
 services:
   otel:
     image: amazon/aws-otel-collector:latest
     command: --config /config/collector-config.yml --log-level debug
-    volumes:
-      - ./otel:/config
     environment:
-      AWS_ACCESS_KEY_ID: ${ACCESS_KEY}
-      AWS_SECRET_ACCESS_KEY: ${SECRET_ACCESS_KEY}
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
+    volumes:
+      - .:/config
     ports:
-      - '55680:55680'
+      - '4317:4317'
+
+  app:
+    image: ${APP_IMAGE}
+    environment:
+      - INSTANCE_ID
+      - LISTEN_ADDRESS
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=aws-otel-integ-test
+      - OTEL_EXPORTER_OTLP_ENDPOINT=otel:4317
+      - OTEL_EXPORTER_OTLP_INSECURE=true
+      - AWS_REGION=us-west-2
+    ports:
+      - '4567:4567'
+      - '8080:8080'
+
+  validator:
+    image: public.ecr.aws/aws-otel-test/aws-otel-test-validator:alpha
+    command: ${VALIDATOR_COMMAND}
+    depends_on:
+      - otel
+      - app
+    environment:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
+      - AWS_REGION=us-west-2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          context: sample-apps
+          context: .
+          file: sample-apps/Dockerfile
           tags: |
             public.ecr.aws/aws-otel-test/js-node:${{ github.sha }}
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,51 +45,32 @@ jobs:
         with:
             path: /tmp/.buildx-cache
             key: ${{ runner.os }}-buildx-${{ github.sha }}
-      - name: Configure AWS Credentials
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
-          aws-region: us-west-2
-      - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v1
-      - name: Build image
-        run : docker build --tag "611364707713.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-otel-js-sample-app:${{ github.sha }}" --file sample-apps/Dockerfile .
-      - name: Push to ECR
-        run : docker push "611364707713.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-otel-js-sample-app:${{ github.sha }}"
-      - name: Setup and Run Otel collector
-        run: |
-          docker-compose -f .github/collector/docker-compose.yml up &
-        env:
-          ACCESS_KEY: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
-          SECRET_ACCESS_KEY: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
-
-      - name: Run Http App with Instrumentation
-        run: |
-          docker run -e AWS_ACCESS_KEY_ID=${{ secrets.INTEG_TEST_AWS_KEY_ID }} \
-                     -e AWS_SECRET_ACCESS_KEY=${{ secrets.INTEG_TEST_AWS_KEY_SECRET }} \
-                     -e AWS_REGION=us-west-2 \
-                     -e INSTANCE_ID=${{ github.run_id }}-${{ github.run_number }} \
-                     -e LISTEN_ADDRESS=0.0.0.0:8080 \
-                     -e OTEL_EXPORTER_OTLP_ENDPOINT=172.17.0.1:55680 \
-                     -e OTEL_RESOURCE_ATTRIBUTES="aws-otel-integ-test" \
-                     -e OTEL_EXPORTER_OTLP_INSECURE=True \
-                     -p 8080:8080 611364707713.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-otel-js-sample-app:${{ github.sha }} &
-      
-      - name: Directory to checkout test framework
-        run: mkdir test-framework 
-
-      - name: Checkout test framework
-        uses: actions/checkout@v2
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          role-duration-seconds: 1200
+          aws-region: us-east-1
+      - name: Login to ECR
+        uses: docker/login-action@v1
         with:
-          repository: aws-observability/aws-otel-test-framework
-          ref: terraform
-          path: test-framework
-
-      - name: Run testing suite
-        run: ./gradlew :validator:run --args='-c js-otel-trace-metric-validation.yml --endpoint http://127.0.0.1:8080 --metric-namespace aws-otel-integ-test -t ${{ github.run_id }}-${{ github.run_number }}'
+          registry: public.ecr.aws
+      - name: Build and push docker image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: sample-apps
+          tags: |
+            public.ecr.aws/aws-otel-test/js-node:${{ github.sha }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+      - name: Run test containers
+        run: docker-compose up --abort-on-container-exit
+        working-directory: .github/collector
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
-          AWS_REGION: us-west-2
-        working-directory: test-framework
+          INSTANCE_ID: ${{ github.run_id }}-${{ github.run_number }}
+          LISTEN_ADDRESS: 0.0.0.0:8080
+          APP_IMAGE: public.ecr.aws/aws-otel-test/js-node:${{ github.sha }}
+          VALIDATOR_COMMAND: -c js-otel-trace-metric-validation.yml --endpoint http://app:8080 --metric-namespace aws-otel-integ-test -t ${{ github.run_id }}-${{ github.run_number }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-          
+
       - run : npm install --ignore-scripts
       - run : npx lerna bootstrap --no-ci
       - run : npm run test


### PR DESCRIPTION
…ublic ecr

Tests are currently failing on main probably due to need for maintenance I think. But this brings them up to our current pattern, which should also make debugging failures much easier by having all the logs in the docker-compose step.