### PR TITLE
Updated sample app to latest upstream

### DIFF
--- a/sample-apps/README.md
+++ b/sample-apps/README.md
@@ -13,9 +13,7 @@ Run the following commands to start the sample app:
 
 ```bash
 git clone https://github.com/aws-observability/aws-otel-js.git
-cd aws-otel-js
-npx lerna bootstrap
-cd sample-apps
+cd aws-otel-js/sample-apps
 npm install
 npm rb
 export LISTEN_ADDRESS=localhost:8080

--- a/sample-apps/metric-emitter.js
+++ b/sample-apps/metric-emitter.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { ConsoleLogger, LogLevel } = require('@opentelemetry/core');
 const { CollectorMetricExporter } = require('@opentelemetry/exporter-collector-grpc');
 const { MeterProvider } = require('@opentelemetry/metrics');
 
@@ -10,7 +9,6 @@ const API_LATENCY_METRIC = 'latency';
 /** The OTLP Metrics gRPC Collector */
 const metricExporter = new CollectorMetricExporter({
     serviceName: process.env.OTEL_RESOURCE_ATTRIBUTES ? process.env.OTEL_RESOURCE_ATTRIBUTES : 'aws-otel-integ-test',
-    logger: new ConsoleLogger(LogLevel.DEBUG),
     url: process.env.OTEL_EXPORTER_OTLP_ENDPOINT ? process.env.OTEL_EXPORTER_OTLP_ENDPOINT : 'localhost:55680'
 });
 

--- a/sample-apps/metrics.js
+++ b/sample-apps/metrics.js
@@ -1,13 +1,11 @@
 'use strict';
 
-const { ConsoleLogger, LogLevel } = require('@opentelemetry/core');
 const { CollectorMetricExporter } = require('@opentelemetry/exporter-collector-grpc');
 const { MeterProvider } = require('@opentelemetry/metrics');
 
 /** The OTLP Metrics gRPC Collector */
 const metricExporter = new CollectorMetricExporter({
   serviceName: 'aws-otel-js-sample',
-  logger: new ConsoleLogger(LogLevel.DEBUG),
   url: (process.env.OTEL_EXPORTER_OTLP_ENDPOINT) ? process.env.OTEL_EXPORTER_OTLP_ENDPOINT : "localhost:55680"
 });
 

--- a/sample-apps/package.json
+++ b/sample-apps/package.json
@@ -17,17 +17,17 @@
     "node": ">=8"
   },
   "dependencies": {
-    "@opentelemetry/api": "0.18.0",
-    "@opentelemetry/core": "^0.18.0",
-    "@opentelemetry/exporter-collector-grpc": "^0.18.0",
-    "@opentelemetry/node": "^0.18.0",
-    "@opentelemetry/plugin-http": "^0.18.0",
-    "@opentelemetry/plugin-https": "^0.18.0",
-    "@opentelemetry/tracing": "^0.18.0",
+    "@opentelemetry/api": "^1.0.0-rc.0",
+    "@opentelemetry/core": "^0.19.0",
+    "@opentelemetry/exporter-collector-grpc": "^0.19.0",
+    "@opentelemetry/node": "^0.19.0",
+    "@opentelemetry/instrumentation": "^0.19.0",
+    "@opentelemetry/instrumentation-http": "^0.19.0",
+    "@opentelemetry/tracing": "^0.19.0",
     "aws-sdk": "^2.799.0",
-    "AWSXRayIdGenerator": "file:../packages/opentelemetry-id-generator-aws-xray",
-    "AWSXRayPropagator": "file:../packages/opentelemetry-propagator-aws-xray",
-    "opentelemetry-plugin-aws-sdk": "0.0.13"
+    "@opentelemetry/id-generator-aws-xray": "^0.16.0",
+    "@opentelemetry/propagator-aws-xray": "^0.16.0",
+    "opentelemetry-instrumentation-aws-sdk": "^0.4.1"
   },
   "devDependencies": {
     "@lerna/link": "^3.21.0",

--- a/sample-apps/tracer.js
+++ b/sample-apps/tracer.js
@@ -23,8 +23,7 @@ const { CollectorTraceExporter } = require('@opentelemetry/exporter-collector-gr
 const { AWSXRayPropagator } = require('AWSXRayPropagator');
 const { AwsXRayIdGenerator } = require('AWSXRayIdGenerator');
 
-const { propagation, trace } = require("@opentelemetry/api");
-const { DiagConsoleLogger, DiagLogLevel, diag } = require('@opentelemetry/api');
+const { DiagConsoleLogger, DiagLogLevel, diag, propagation, trace } = require("@opentelemetry/api");
 
 module.exports = (serviceName) => {
   // set global propagator

--- a/sample-apps/tracer.js
+++ b/sample-apps/tracer.js
@@ -16,7 +16,6 @@
 
 'use strict'
 
-const { LogLevel } = require("@opentelemetry/core");
 const { SimpleSpanProcessor, ConsoleSpanExporter } = require("@opentelemetry/tracing");
 const { NodeTracerProvider } = require('@opentelemetry/node');
 const { CollectorTraceExporter } = require('@opentelemetry/exporter-collector-grpc');
@@ -25,14 +24,15 @@ const { AWSXRayPropagator } = require('AWSXRayPropagator');
 const { AwsXRayIdGenerator } = require('AWSXRayIdGenerator');
 
 const { propagation, trace } = require("@opentelemetry/api");
+const { DiagConsoleLogger, DiagLogLevel, diag } = require('@opentelemetry/api');
 
 module.exports = (serviceName) => {
   // set global propagator
   propagation.setGlobalPropagator(new AWSXRayPropagator());
+  diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ERROR);
 
   // create a provider for activating and tracking with AWS IdGenerator
   const tracerConfig = {
-    logLevel: LogLevel.ERROR,
     idGenerator: new AwsXRayIdGenerator(),
     plugins: {
       https: {


### PR DESCRIPTION
Fixes the issue that caused this build to fail: https://github.com/aws-observability/aws-otel-js/runs/2150739907?check_suite_focus=true

The upstream OTel JS refactored their SDK logger to a `diagLogger` in the API package. This change won't affect the logging behavior in the sample app, just updates it to use the new logging APIs.