### PR TITLE
Paths relative to project root for Dockerfile

### DIFF
--- a/sample-apps/Dockerfile
+++ b/sample-apps/Dockerfile
@@ -4,6 +4,6 @@ WORKDIR /usr/src/app
 
 COPY . .
 
-RUN npm install
+RUN cd sample-apps && npm install
 
-CMD ["node", "server.js" ]
+CMD ["node", "sample-apps/server.js" ]


### PR DESCRIPTION
# Description

In #58 , I had built the Docker image locally and seen it work fine with these commands, but now I realize that the github-action builds from the root directory. It should be enough to `cd sample-apps && npm install && cd ../` first (with the last cd being implicit because the docker image is run from the root) and then do `node sample-apps/server.js`.

This PR adds that fix.