### PR TITLE
Add schema to exporter endpoint

### DIFF
--- a/.github/collector/docker-compose.yml
+++ b/.github/collector/docker-compose.yml
@@ -20,11 +20,9 @@ services:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - AWS_SESSION_TOKEN
-      - OTEL_EXPORTER_OTLP_ENDPOINT=otel:4317
-      - OTEL_EXPORTER_OTLP_INSECURE=true
+      - OTEL_EXPORTER_OTLP_ENDPOINT=grpc://otel:4317
       - AWS_REGION=us-west-2
     ports:
-      - '4567:4567'
       - '8080:8080'
 
   validator:


### PR DESCRIPTION
# Description

When the specification changed [to enforce a schema](https://github.com/open-telemetry/opentelemetry-specification/pull/1234), upstream OTel JS also changed the validation on the schema [to attempt to construct a URL object out of the exporter endpoint](https://github.com/open-telemetry/opentelemetry-js/blob/fd2410cc9e8d43210b6ea44b8193fa70ee900499/packages/opentelemetry-exporter-collector-grpc/src/util.ts#L123). It will return `new URL().host` as the endpoint.

This caused a problem for us because `new URL('otel:4317')` will interpret this as 

```
protocol: 'otel:',
host: '',
pathname: '4317'
```

That's why we should do `new URL('grpc://otel:4317')` so it will be
```
protocol: 'grpc:',
host: 'otel:4317',
port: '4317',
```

and return the correct host.