### PR TITLE
Use upstream benchmark action + update issues when names match

### DIFF
--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -188,12 +188,12 @@ jobs:
           git checkout main;
           [[ $HAS_RESULTS_ALREADY == true ]]
       - name: Graph and Report Performance Test Averages result
-        uses: NathanielRN/github-action-benchmark@v1.8.3-alpha3
+        uses: benchmark-action/github-action-benchmark@v1.10.0
         continue-on-error: true
         id: check-failure-after-performance-tests
         with:
           name: Soak Test Results - sample-app-${{ matrix.app-platform }}-${{ matrix.instrumentation-type }}
-          tool: custombenchmark
+          tool: customSmallerIsBetter
           output-file-path: output.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           max-items-in-chart: ${{ env.MAX_BENCHMARKS_TO_KEEP }}
@@ -217,6 +217,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           filename: .github/auto-issue-templates/failure-during-soak_tests.md
+          update_existing: true
       - name: Publish Issue if failed AFTER Performance Tests
         uses: JasonEtco/create-an-issue@v2
         if: ${{ github.event_name == 'schedule' &&


### PR DESCRIPTION
# Description

Two updates to the Soak Tests are introduced in this PR:

1. We were super fortunate to get upstream's help to get our modifications to the `benchmark-action/github-action-benchmark` GitHub action merged and released upstream in https://github.com/benchmark-action/github-action-benchmark/pull/81 ! This way, we can use their action instead of my fork 😄 
2. Following https://github.com/aws-observability/aws-otel-java-instrumentation/pull/101#issuecomment-945999532 we found that instead of creating multiple issues when one benchmarking issue is detected, we would be better off updating the existing issue using a feature already available from the GitHub action we use. This way we will only have one issue for multiple failed Soak Test runs from a schedule instead of multiple issues.
