### PR TITLE
Edit benchmark output file format for GH action

### DIFF
--- a/.github/scripts/performance-tests/get-metric-data/produce_performance_test_results.py
+++ b/.github/scripts/performance-tests/get-metric-data/produce_performance_test_results.py
@@ -68,33 +68,31 @@ if __name__ == "__main__":
     )["MetricDataResults"]
 
     benchmarks_json = json.dumps(
-        {
-            "benchmarks": [
-                {
-                    "Name": "Soak Test Average CPU Load",
-                    "Value": mean(
-                        next(
-                            metric_data
-                            for metric_data in metric_data_results
-                            if metric_data["Id"] == "cpu_load_expr"
-                        )["Values"]
-                    ),
-                    "Unit": "Percent",
-                },
-                {
-                    "Name": "Soak Test Average Virtual Memory Used",
-                    "Value": mean(
-                        next(
-                            metric_data
-                            for metric_data in metric_data_results
-                            if metric_data["Id"] == "total_memory_expr"
-                        )["Values"]
-                    )
-                    / (2 ** 20),
-                    "Unit": "Megabytes",
-                },
-            ]
-        },
+        [
+            {
+                "name": "Soak Test Average CPU Load",
+                "value": mean(
+                    next(
+                        metric_data
+                        for metric_data in metric_data_results
+                        if metric_data["Id"] == "cpu_load_expr"
+                    )["Values"]
+                ),
+                "unit": "Percent",
+            },
+            {
+                "name": "Soak Test Average Virtual Memory Used",
+                "value": mean(
+                    next(
+                        metric_data
+                        for metric_data in metric_data_results
+                        if metric_data["Id"] == "total_memory_expr"
+                    )["Values"]
+                )
+                / (2 ** 20),
+                "unit": "Megabytes",
+            },
+        ],
         indent=4,
     )
 

--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -188,7 +188,7 @@ jobs:
           git checkout main;
           [[ $HAS_RESULTS_ALREADY == true ]]
       - name: Graph and Report Performance Test Averages result
-        uses: benchmark-action/github-action-benchmark@v1.10.0
+        uses: benchmark-action/github-action-benchmark@v1
         continue-on-error: true
         id: check-failure-after-performance-tests
         with:


### PR DESCRIPTION
# Description

Follow up to #71 where we switched over to using the upstream GitHub benchmark action.

In the upstream version of this GH action, the format of the `output.json` file which has the benchmarks is different from the one we were originally using. This made [the Soak tests fail](https://github.com/aws-observability/aws-otel-js/runs/4060588832?check_suite_focus=true).

In this PR we fix the format to match upstream, and also relax the strict version pinning so that non-breaking changes are accepted.