### PR TITLE
Add missing flag to update existing GH issue

### DIFF
--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -228,6 +228,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           filename: .github/auto-issue-templates/failure-after-soak_tests.md
+          update_existing: true
       - name: Check for Performance Degradation either DURING or AFTER Performance Tests
         if: ${{ steps.check-failure-during-performance-tests.outcome == 'failure' ||
           steps.check-failure-after-performance-tests.outcome == 'failure' }}


### PR DESCRIPTION
# Description

As noticed in #74 #73 #72, the issues were creating multiple issues instead of just 1 single one. This is because even though I added the `update_existing: true: flag to one of the steps that creates an issue, I neglected to create it for the other one.

This PR fixes that.