### PR TITLE
Update pr-build.yml to use latest Node

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -14,7 +14,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
 
-        node-version: [14.x]
+        node-version: [24.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Change from 14x to 24x per https://nodejs.org/en/about/previous-releases

This is blocking https://github.com/aws-observability/aws-otel-js/pull/186

Testing: PR workflow is sufficient to test this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
