### PR TITLE
Pin GitHub Action references to commit SHAs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,11 +37,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 #v2.28.1
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -52,7 +52,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 #v2.28.1
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -66,4 +66,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 #v2.28.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,26 +12,26 @@ jobs:
       id-token: write
     steps:
       - name : Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 #v2.10.0
       - name: Cache Docker layer
-        uses: actions/cache@v2
+        uses: actions/cache@2b250bc32ad02700b996b496c14ac8c2840a2991 #v2.1.8
         with:
             path: /tmp/.buildx-cache
             key: ${{ runner.os }}-buildx-${{ github.sha }}
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 #v1.7.0
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           role-duration-seconds: 1200
           aws-region: us-east-1
       - name: Login to ECR
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc #v2.2.0
         with:
           registry: public.ecr.aws
       - name: Build and push docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 #v3.3.1
         with:
           push: true
           context: sample-apps

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -19,9 +19,9 @@ jobs:
         node-version: [24.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 #v3.9.1
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -29,3 +29,28 @@ jobs:
         run: |
           cd sample-apps
           npm install --ignore-scripts
+
+  static-code-checks:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #5.0.0
+        with:
+          fetch-depth: 0
+      - name: Check for versioned GitHub actions
+        if: always()
+        run: |
+          # Get changed GitHub workflow/action files
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}..HEAD | grep -E "^\.github/(workflows|actions)/.*\.ya?ml$" || true)
+          
+          if [ -n "$CHANGED_FILES" ]; then
+            # Check for any versioned actions, excluding comments and this validation script
+            VIOLATIONS=$(grep -Hn "uses:.*@v" $CHANGED_FILES | grep -v "grep.*uses:.*@v" | grep -v "#.*@v" || true)
+            if [ -n "$VIOLATIONS" ]; then
+              echo "Found versioned GitHub actions. Use commit SHAs instead:"
+              echo "$VIOLATIONS"
+              exit 1
+            fi
+          fi
+          
+          echo "No versioned actions found in changed files"

--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           echo "$TEST_DURATION_MINUTES" | tee --append $GITHUB_ENV;
       - name: Clone This Repo @ ${{ env.TARGET_SHA }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2.7.0
         with:
           ref: ${{ env.TARGET_SHA }}
 
@@ -92,7 +92,7 @@ jobs:
     # MARK: - Run Performance Tests
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 #v1.7.0
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           role-duration-seconds: 21600 # 6 Hours
@@ -192,7 +192,7 @@ jobs:
           git checkout main;
           [[ $HAS_RESULTS_ALREADY == true ]]
       - name: Graph and Report Performance Test Averages result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@a7bc2366eda11037936ea57d811a43b3418d3073 #v1.21.0
         continue-on-error: true
         id: check-failure-after-performance-tests
         with:
@@ -212,7 +212,7 @@ jobs:
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: soak-tests/per-commit-overall-results
       - name: Publish Issue if failed DURING Performance Tests
-        uses: JasonEtco/create-an-issue@v2
+        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 #v2.9.2
         if: ${{ github.event_name == 'schedule' &&
           steps.check-failure-during-performance-tests.outcome == 'failure' }}
         env:
@@ -223,7 +223,7 @@ jobs:
           filename: .github/auto-issue-templates/failure-during-soak_tests.md
           update_existing: true
       - name: Publish Issue if failed AFTER Performance Tests
-        uses: JasonEtco/create-an-issue@v2
+        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 #v2.9.2
         if: ${{ github.event_name == 'schedule' &&
           steps.check-failure-after-performance-tests.outcome == 'failure' }}
         env:

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Mark the issues/pr
-        uses: actions/stale@v6
+        uses: actions/stale@5ebf00ea0e4c1561e9b43a292ed34424fb1d4578 #v6.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} #Github workflow will add a temporary token when executing the workflow
         with:


### PR DESCRIPTION
## Summary

Pin all GitHub Action references to full commit SHAs instead of mutable version tags to prevent supply chain attacks. This is a security best practice recommended by [GitHub's security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

Mutable version tags (e.g. `@v2`) can be moved to point to different commits, meaning a compromised upstream action could execute malicious code in our workflows. Pinning to commit SHAs ensures we always run the exact code we've reviewed.

## Changes

| Old Reference | New Reference | Hash | Version |
|--------------|---------------|------|---------|
| actions/cache@v2 | actions/cache@2b250bc32ad02700b996b496c14ac8c2840a2991 | 2b250bc32ad02700b996b496c14ac8c2840a2991 | [v2.1.8](https://github.com/actions/cache/releases/tag/v2.1.8) |
| actions/checkout@v2 | actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 | ee0669bd1cc54295c223e0bb666b733df41de1c5 | [v2.7.0](https://github.com/actions/checkout/releases/tag/v2.7.0) |
| actions/setup-node@v3 | actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 | 3235b876344d2a9aa001b8d1453c930bba69e610 | [v3.9.1](https://github.com/actions/setup-node/releases/tag/v3.9.1) |
| actions/stale@v6 | actions/stale@5ebf00ea0e4c1561e9b43a292ed34424fb1d4578 | 5ebf00ea0e4c1561e9b43a292ed34424fb1d4578 | [v6.0.1](https://github.com/actions/stale/releases/tag/v6.0.1) |
| aws-actions/configure-aws-credentials@v1 | aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 | 67fbcbb121271f7775d2e7715933280b06314838 | [v1.7.0](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v1.7.0) |
| benchmark-action/github-action-benchmark@v1 | benchmark-action/github-action-benchmark@a7bc2366eda11037936ea57d811a43b3418d3073 | a7bc2366eda11037936ea57d811a43b3418d3073 | [v1.21.0](https://github.com/benchmark-action/github-action-benchmark/releases/tag/v1.21.0) |
| docker/build-push-action@v3 | docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 | 1104d471370f9806843c095c1db02b5a90c5f8b6 | [v3.3.1](https://github.com/docker/build-push-action/releases/tag/v3.3.1) |
| docker/login-action@v2 | docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc | 465a07811f14bebb1938fbed4728c6a1ff8901fc | [v2.2.0](https://github.com/docker/login-action/releases/tag/v2.2.0) |
| docker/setup-buildx-action@v2 | docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 | 885d1462b80bc1c1c7f0b00334ad271f09369c55 | [v2.10.0](https://github.com/docker/setup-buildx-action/releases/tag/v2.10.0) |
| github/codeql-action/analyze@v2 | github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 | b8d3b6e8af63cde30bdc382c0bc28114f4346c88 | [v2.28.1](https://github.com/github/codeql-action/releases/tag/v2.28.1) |
| github/codeql-action/autobuild@v2 | github/codeql-action/autobuild@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 | b8d3b6e8af63cde30bdc382c0bc28114f4346c88 | [v2.28.1](https://github.com/github/codeql-action/releases/tag/v2.28.1) |
| github/codeql-action/init@v2 | github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 | b8d3b6e8af63cde30bdc382c0bc28114f4346c88 | [v2.28.1](https://github.com/github/codeql-action/releases/tag/v2.28.1) |
| JasonEtco/create-an-issue@v2 | JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 | 1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 | [v2.9.2](https://github.com/JasonEtco/create-an-issue/releases/tag/v2.9.2) |

## Static Code Check

Added a `static-code-checks` job to `pr-build.yml` that will fail PRs introducing mutable GitHub Action version references.
